### PR TITLE
More direct link to the animation

### DIFF
--- a/.github/workflows/record_animation.yml
+++ b/.github/workflows/record_animation.yml
@@ -9,4 +9,4 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Record and deploy the animation
-        uses: cyberbotics/webots-animation-action@develop
+        uses: cyberbotics/webots-animation-action@master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webots Visual Tracking Example
 
-[![Webots Badge](https://badgen.net/badge/icon/Preview%20simulation?label=Webots)](https://lukicdarkoo.github.io/webots-example-visual-tracking/)
+[![Webots Badge](https://badgen.net/badge/icon/Preview%20simulation?label=Webots)](https://lukicdarkoo.github.io/webots-example-visual-tracking/master)
 [![Stack Overflow Badge](https://badgen.net/badge/icon/Show%20question?label=Stack%20Overflow&color=orange)](https://stackoverflow.com/questions/64027373/rotation-in-certain-direction-in-webots)
 
 This example shows a robot following a red ball in Webots.


### PR DESCRIPTION
Following-up the new version of the GitHub action for Webots animations, it seems better that the badge points directly to the animation of the master branch.